### PR TITLE
support pytorch v0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-
-.idea/
-V-REP_PRO_EDU_V3_5_0_Linux/
-V-REP_PRO_EDU_V3_6_1_Ubuntu16_04/
-
-
 catkin_ws/build
 catkin_ws/devel
 
@@ -27,3 +21,4 @@ realsense/realsense
 commands.txt
 visualization.push.png
 visualization.grasp.png
+

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ realsense/realsense
 commands.txt
 visualization.push.png
 visualization.grasp.png
-

--- a/trainer.py
+++ b/trainer.py
@@ -1,5 +1,6 @@
 import os
 import time
+from collections import OrderedDict
 import numpy as np
 import cv2
 import torch
@@ -59,7 +60,17 @@ class Trainer(object):
 
         # Load pre-trained model
         if load_snapshot:
-            self.model.load_state_dict(torch.load(snapshot_file))
+
+            # PyTorch v0.4 removes periods in state dict keys, but no backwards compatibility :(
+            loaded_snapshot_state_dict = torch.load(snapshot_file)
+            loaded_snapshot_state_dict = OrderedDict([(k.replace('conv.1','conv1'), v) if k.find('conv.1') else (k, v) for k, v in loaded_snapshot_state_dict.items()])
+            loaded_snapshot_state_dict = OrderedDict([(k.replace('norm.1','norm1'), v) if k.find('norm.1') else (k, v) for k, v in loaded_snapshot_state_dict.items()])
+            loaded_snapshot_state_dict = OrderedDict([(k.replace('conv.2','conv2'), v) if k.find('conv.2') else (k, v) for k, v in loaded_snapshot_state_dict.items()])
+            loaded_snapshot_state_dict = OrderedDict([(k.replace('norm.2','norm2'), v) if k.find('norm.2') else (k, v) for k, v in loaded_snapshot_state_dict.items()])
+            self.model.load_state_dict(loaded_snapshot_state_dict)
+
+            # self.model.load_state_dict(torch.load(snapshot_file)) # Old loading command pre v0.4
+
             print('Pre-trained model snapshot loaded from: %s' % (snapshot_file))
 
         # Convert model from CPU to GPU


### PR DESCRIPTION
A not-thorough migration to support pytorch>= 0.4, solve issue [12](https://github.com/andyzeng/visual-pushing-grasping/issues/12), includes:
1. use with torch.no_grad() to solve the gpu memory issue
2. loss.item() to solve the "indexing 0-dimension" problem

As @st2yang pointed out [here](https://github.com/andyzeng/visual-pushing-grasping/issues/12#issuecomment-489228210), it can still use the provided trained weights. 

A more thorough migration is on my [branch](https://github.com/Kelvinson/visual-pushing-grasping/tree/dong-patch-1.1), but it needs training from scratch and there is nan error.

Note the both of two branches **only work for V-REP 3.5**. A hack around to adapt V3.6 is welcome. Have fun!